### PR TITLE
1.0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,25 @@ As of the current release, the plugin does not allow customization of axe-core's
 
 ## 🖌 Customization
 
-The plugin comes with a predefined set of CSS styles to make the results readable and organized. You can customize the styles by editing the a11y-styles.css file.
+### Overriding Plugin Styles
+
+To allow for more flexible styling customization, the plugin supports the ability to override the default styles. You can do this by placing a cloned version of the `a11y-styles.css` file in your active theme folder, inside a sub-folder named `a11y-tester`.
+
+For example, the structure should be as follows:
+
+```plaintext
+- wp-content
+    - themes
+        - your-active-theme
+            - a11y-tester
+                - a11y-styles.css
+```
+
+When this file is detected in the active theme folder, the plugin will automatically enqueue this style sheet in place of the default one, allowing you to customize the styles as you see fit.
+
+If the file is not found in the active theme folder, the plugin will fall back to using the default styles located in the plugin directory.
+
+To implement this, make sure to update your CSS and keep it in sync with the `a11y-styles.css` file in the `a11y-tester` folder of your active theme.
 
 ## 📜 License
 

--- a/a11y-styles.css
+++ b/a11y-styles.css
@@ -1,3 +1,32 @@
+/* Define global colors for impact and other common styles */
+:root {
+    /* Impact colors */
+    --impact-minor: #ffe082;
+    --impact-minor-text: #000;
+    --impact-moderate: #90caf9;
+    --impact-moderate-text: #000;
+    --impact-serious: #ef9a9a;
+    --impact-serious-text: #000;
+    --impact-critical: #d32f2f;
+    --impact-critical-text: #fff;
+
+    /* Common styles */
+    --border-radius: 4px;
+    --border-color: #e0e0e0;
+    --box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+    --btn-padding: 6px 12px;
+    --font-size-14: 14px;
+    --font-size-16: 16px;
+    --transition: background-color 0.3s;
+    --hover-bg-btn: #155a8a;
+    --run-test-bg-btn: #4caf50;
+    --run-test-text-btn: #fff;
+    --clear-test-bg-btn: #fedad7;
+    --clear-test-text-btn: #565656;
+    --table-header-bg: #f2f2f2;
+    --table-border: #ccc;
+}
+
 /* CSS Reset for Specific Elements */
 #a11y-results *,
 #a11y-results *::before,
@@ -12,7 +41,7 @@
 #a11y-results {
     margin-top: 20px;
     padding: 10px;
-    border-radius: 4px;
+    border-radius: var(--border-radius);
     box-sizing: border-box;
 }
 
@@ -20,10 +49,10 @@
 #a11y-results > div {
     margin: 15px 0;
     padding: 12px;
-    border: 1px solid #e0e0e0;
-    border-radius: 4px;
+    border: 1px solid var(--border-color);
+    border-radius: var(--border-radius);
     background: #fff;
-    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+    box-shadow: var(--box-shadow);
 }
 
 /* Collapsible buttons */
@@ -35,24 +64,24 @@
     width: 100%;
     text-align: left;
     outline: none;
-    font-size: 14px;
+    font-size: var(--font-size-14);
     border: none;
-    border-radius: 4px;
-    transition: background-color 0.3s;
+    border-radius: var(--border-radius);
+    transition: var(--transition);
 }
 
 #a11y-results button.collapsible:active,
 #a11y-results button.collapsible:hover {
-    background-color: #155a8a;
+    background-color: var(--hover-bg-btn);
 }
 
 /* Content blocks */
 #a11y-results div.a11y-content {
     padding: 10px;
-    display: none; /* set to none for accordions to default closed */
+    display: none;
     overflow: hidden;
     background-color: #f9f9f9;
-    border-radius: 4px;
+    border-radius: var(--border-radius);
     margin-top: 5px;
 }
 
@@ -61,16 +90,16 @@
     width: 100%;
     margin: 10px 0;
     border-collapse: collapse;
-    border-radius: 4px;
-    border: 1px solid #ccc;
+    border-radius: var(--border-radius);
+    border: 1px solid var(--table-border);
 }
 
 /* Table Headers */
 #a11y-results th {
-    background-color: #f2f2f2;
+    background-color: var(--table-header-bg);
     padding: 8px;
     text-align: left;
-    border: 1px solid #ccc;
+    border: 1px solid var(--table-border);
     width: 15%;
     white-space: normal;
     word-wrap: break-word;
@@ -80,7 +109,7 @@
 #a11y-results td {
     padding: 8px;
     text-align: left;
-    border: 1px solid #ccc;
+    border: 1px solid var(--table-border);
     white-space: normal;
     word-wrap: break-word;
 }
@@ -97,71 +126,72 @@
 
 /* Impact-based colors */
 #a11y-results button.collapsible.impact-minor {
-    background-color: #ffe082;
-    color: #000;
+    background-color: var(--impact-minor);
+    color: var(--impact-minor-text);
 }
 
 #a11y-results button.collapsible.impact-moderate {
-    background-color: #90caf9;
-    color: #000;
+    background-color: var(--impact-moderate);
+    color: var(--impact-moderate-text);
 }
 
 #a11y-results button.collapsible.impact-serious {
-    background-color: #ef9a9a;
-    color: #000;
+    background-color: var(--impact-serious);
+    color: var(--impact-serious-text);
 }
 
 #a11y-results button.collapsible.impact-critical {
-    background-color: #d32f2f;
-    color: white;
+    background-color: var(--impact-critical);
+    color: var(--impact-critical-text);
 }
 
 #a11y-results tr td.impact-minor {
-    background-color: #ffe082;
-    color: #000;
+    background-color: var(--impact-minor);
+    color: var(--impact-minor-text);
 }
 
 #a11y-results tr td.impact-moderate {
-    background-color: #90caf9;
-    color: #000;
+    background-color: var(--impact-moderate);
+    color: var(--impact-moderate-text);
 }
 
 #a11y-results tr td.impact-serious {
-    background-color: #ef9a9a;
-    color: #000;
+    background-color: var(--impact-serious);
+    color: var(--impact-serious-text);
 }
 
 #a11y-results tr td.impact-critical {
-    background-color: #d32f2f;
-    color: white;
+    background-color: var(--impact-critical);
+    color: var(--impact-critical-text);
 }
 
 /* Buttons */
 #run-a11y-test-button,
 #clear-a11y-test-button {
     border: none;
-    color: white;
-    padding: 12px 24px;
+    padding: var(--btn-padding);
     text-align: center;
-    font-size: 16px;
+    font-size: var(--font-size-16);
     margin: 4px 2px;
     cursor: pointer;
-    border-radius: 4px;
-    transition: background-color 0.3s;
+    border-radius: var(--border-radius);
+    transition: var(--transition);
 }
 
 #run-a11y-test-button {
-    background-color: #4caf50;
+    background-color: var(--run-test-bg-btn);
+    color: var(--run-test-text-btn);
 }
 
 #run-a11y-test-button:hover {
-    background-color: #45a049;
+    filter: brightness(90%);
 }
 
 #clear-a11y-test-button {
-    background-color: #f44336;
+    background-color: var(--clear-test-bg-btn);
+    color: var(--clear-test-text-btn);
 }
 
 #clear-a11y-test-button:hover {
-    background-color: #d32f2f;
+    filter: brightness(90%);
 }

--- a/a11y-tester.php
+++ b/a11y-tester.php
@@ -3,12 +3,11 @@
 /**
  * Plugin Name: A11y Tester
  * Description: A plugin to test accessibility of any page or post.
- * Version: 1.0.2
+ * Version: 1.0.3
  * Author: Joe Peterson
  * Author URI: https://joepeterson.work
  */
 
-// Enqueue scripts
 function enqueue_a11y_scripts($hook)
 {
     if ('post.php' === $hook || 'post-new.php' === $hook) {
@@ -17,61 +16,58 @@ function enqueue_a11y_scripts($hook)
 
         $nonce = wp_create_nonce('a11y_nonce');
         wp_localize_script('a11y-init', 'wpData', array('ajax_url' => admin_url('admin-ajax.php'), 'nonce' => $nonce));
-        wp_enqueue_style('a11y-style', plugin_dir_url(__FILE__) . 'a11y-styles.css', array(), '1.0');
+
+        $theme_css_path = get_stylesheet_directory() . '/a11y-override-styles.css';
+        $theme_css_url = get_stylesheet_directory_uri() . '/a11y-override-styles.css';
+        $plugin_css_url = plugin_dir_url(__FILE__) . 'a11y-styles.css';
+
+        if (file_exists($theme_css_path)) {
+            wp_enqueue_style('a11y-style', $theme_css_url, array(), '1.0');
+        } else {
+            wp_enqueue_style('a11y-style', $plugin_css_url, array(), '1.0');
+        }
     }
 }
 add_action('admin_enqueue_scripts', 'enqueue_a11y_scripts');
 
-// Add meta box
 function add_a11y_meta_box()
 {
-    // Fetch all public post types
     $args = array(
-        'public'   => true,
+        'public' => true,
     );
 
     $post_types = get_post_types($args);
-
-    // Loop through each post type and add the meta box
     foreach ($post_types as $post_type) {
         add_meta_box('a11y_meta_box', 'Accessibility Tester', 'a11y_meta_box_content', $post_type, 'normal', 'high');
     }
 }
 add_action('add_meta_boxes', 'add_a11y_meta_box');
 
-
-// Meta box content
 function a11y_meta_box_content()
 {
     echo '<div class="inside"></div>';
 }
 
-// AJAX handler
 add_action('wp_ajax_run_a11y_test', 'run_a11y_test_function');
-
 function run_a11y_test_function()
 {
-    // Check the nonce and capability
     check_ajax_referer('a11y_nonce', 'security');
     if (!current_user_can('edit_posts')) {
         wp_send_json_error('You do not have the necessary permissions.');
         wp_die();
     }
 
-    // Check and sanitize the post ID
     $post_id = intval($_POST['post_id']);
     if ($post_id <= 0) {
         wp_send_json_error('Invalid post ID');
         wp_die();
     }
-    $post_id = absint($post_id); // Sanitizing the input
-
+    $post_id = absint($post_id);
     $url = get_permalink($post_id);
     wp_send_json_success(array('url' => $url));
     wp_die();
 }
 
-// Add custom links
 function a11y_custom_plugin_links($links, $file)
 {
     if (plugin_basename(__FILE__) === $file) {
@@ -81,7 +77,6 @@ function a11y_custom_plugin_links($links, $file)
         );
         return array_merge($links, $row_meta);
     }
-
     return (array) $links;
 }
 add_filter('plugin_row_meta', 'a11y_custom_plugin_links', 10, 2);

--- a/a11y-tester.php
+++ b/a11y-tester.php
@@ -17,8 +17,8 @@ function enqueue_a11y_scripts($hook)
         $nonce = wp_create_nonce('a11y_nonce');
         wp_localize_script('a11y-init', 'wpData', array('ajax_url' => admin_url('admin-ajax.php'), 'nonce' => $nonce));
 
-        $theme_css_path = get_stylesheet_directory() . '/a11y-override-styles.css';
-        $theme_css_url = get_stylesheet_directory_uri() . '/a11y-override-styles.css';
+        $theme_css_path = get_stylesheet_directory() . '/a11y-tester/a11y-styles.css';
+        $theme_css_url = get_stylesheet_directory_uri() . '/a11y-tester/a11y-styles.css';
         $plugin_css_url = plugin_dir_url(__FILE__) . 'a11y-styles.css';
 
         if (file_exists($theme_css_path)) {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: accessibility, a11y, testing, axe-core
 Requires at least: 4.7
 Tested up to: 5.9
 Requires PHP: 7.0
-Stable tag: 1.0.2
+Stable tag: 1.0.3
 License: GPLv3 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 Author: Joe Peterson
@@ -46,7 +46,13 @@ While A11y Tester aims to be as compatible as possible with other themes and plu
 
 == Customization ==
 
-The plugin comes with a predefined set of CSS styles to make the results readable and organized. You can customize the styles by editing the a11y-styles.css file.
+The plugin comes with a predefined set of CSS styles to make the results readable and organized. Starting from version 1.0.3, you can override the default styles by placing a customized `a11y-styles.css` file in the following directory structure:
+
+- wp-content
+    - themes
+        - your-active-theme
+            - a11y-tester
+                - a11y-styles.css
 
 == Screenshots ==
 
@@ -65,6 +71,9 @@ Initial release, no upgrades required.
 
 = 1.0.2 =
 * Added formatting improvements to the result report.
+
+= 1.0.3 =
+* Added support for overriding styles via theme directory.
 
 == License ==
 
@@ -87,3 +96,6 @@ Contributions, issues, and feature requests are welcome! For support, visit the 
 
 = 1.0 =
 * Initial release
+
+= 1.0.3 =
+* Added support for overriding styles via theme directory.


### PR DESCRIPTION
🔧 chore(README.md): update customization section to provide instructions on overriding plugin styles for more flexible styling customization
🔧 chore(a11y-tester.php): update plugin version to 1.0.3
🔧 chore(a11y-tester.php): refactor enqueue_a11y_scripts function to enqueue a11y-styles.css from the active theme folder if it exists, otherwise fallback to the default styles in the plugin directory
🔧 chore(a11y-tester.php): remove unnecessary comments and whitespace
🔧 chore(a11y-tester.php): refactor run_a11y_test_function to remove redundant code and sanitize input
🔧 chore(a11y-tester.php): remove unnecessary comments and whitespace
🔧 chore(a11y-tester.php): refactor a11y_custom_plugin_links to remove unnecessary comments and whitespace
📝 docs(readme.txt): update stable tag to 1.0.3 to reflect the latest version
📝 docs(readme.txt): add instructions for overriding default styles by placing a customized `a11y-styles.css` file in the theme directory
📝 docs(readme.txt): add release notes for version 1.0.3, which includes support for overriding styles via theme directory
🔧 chore(a11y-styles.css): update global colors and common styles to improve accessibility and maintainability
🔧 chore(a11y-styles.css): update border radius, box shadow, and font sizes to use CSS variables for consistency and easier customization
🔧 chore(a11y-styles.css): update button styles to use CSS variables for background color, text color, padding, and transition
🔧 chore(a11y-styles.css): update table styles to use CSS variables for border color, header background color, and table header text color
🔧 chore(a11y-styles.css): update impact-based colors to use CSS variables for consistency and easier customization
🔧 chore(a11y-tester.php): update path and URL for a11y-styles.css to match new file location in a11y-tester directory